### PR TITLE
Ensure dataset with only attachments or alternative exports are properly harvested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ensure dataset with only attachments or alternative exports are properly harvested [#86](https://github.com/opendatateam/udata-ods/pull/86)
 
 ## 1.2.1 (2018-10-02)
 

--- a/tests/data/no-data.json
+++ b/tests/data/no-data.json
@@ -1,0 +1,56 @@
+{
+    "nhits": 2,
+    "parameters": {
+        "timezone": "UTC",
+        "rows": 10,
+        "format": "json",
+        "staged": false
+    },
+    "datasets": [{
+        "datasetid": "test-attachments",
+        "metas": {
+            "domain": "etalab-sandbox",
+            "keyword": "keyword1",
+            "language": "en",
+            "title": "test attachments",
+            "records_count": 0,
+            "modified": "2015-04-09T10:29:11+00:00",
+            "visibility": "domain",
+            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing"
+        },
+        "has_records": false,
+        "features": [],
+        "attachments":[
+            {
+                "url":"odsfile://documentation.pdf",
+                "mimetype":"application/pdf",
+                "id":"documentation_pdf",
+                "title":"Documentation"
+            }
+        ],
+        "alternative_exports":[
+           {
+              "url":"odsfile://gtfs5.zip",
+              "mimetype":"application/zip",
+              "title":"gtfs.zip",
+              "description":"GTFS 15/01",
+              "id":"gtfs_zip"
+           }
+        ],
+        "fields": []
+    }, {
+        "datasetid": "test-empty",
+        "metas": {
+            "domain": "etalab-sandbox",
+            "language": "en",
+            "title": "test-c",
+            "records_count": 0,
+            "modified": "2015-04-10T09:39:13+00:00",
+            "visibility": "domain"
+        },
+        "has_records": false,
+        "features": [],
+        "attachments": [],
+        "fields": []
+    }]
+}

--- a/tests/test_ods_backend.py
+++ b/tests/test_ods_backend.py
@@ -197,6 +197,56 @@ def test_simple(rmock):
 
 
 @pytest.mark.frontend()
+def test_no_data(rmock):
+    org = OrganizationFactory()
+    source = HarvestSourceFactory(backend='ods',
+                                  url=ODS_URL,
+                                  organization=org)
+
+    api_url = ''.join((ODS_URL, '/api/datasets/1.0/search/'))
+    rmock.get(api_url, text=ods_response('no-data.json'),
+              headers={'Content-Type': 'application/json'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) == 2
+    assert job.status == 'done'
+
+    assert Dataset.objects.count() == 1
+
+    d = Dataset.objects.first()
+
+    assert d.title == 'test attachments'
+    assert not d.extras['ods:has_records']
+    assert d.extras['harvest:remote_id'] == 'test-attachments'
+
+    assert len(d.resources) == 2
+
+    resource = d.resources[0]
+    assert resource.title == 'gtfs.zip'
+    assert resource.description == 'GTFS 15/01'
+    assert resource.format == 'zip'
+    assert resource.mime == 'application/zip'
+    assert resource.url == ('http://etalab-sandbox.opendatasoft.com'
+                            '/api/datasets/1.0/test-attachments/alternative_exports'
+                            '/gtfs_zip')
+    assert resource.extras['ods:type'] == 'alternative_export'
+
+    resource = d.resources[1]
+    assert resource.title == 'Documentation'
+    assert resource.description is None
+    assert resource.format == 'pdf'
+    assert resource.mime == 'application/pdf'
+    assert resource.url == ('http://etalab-sandbox.opendatasoft.com'
+                            '/api/datasets/1.0/test-attachments/attachments'
+                            '/documentation_pdf')
+    assert resource.extras['ods:type'] == 'attachment'
+
+
+@pytest.mark.frontend()
 def test_exclude_inspire_default(rmock):
     org = OrganizationFactory()
     source = HarvestSourceFactory(backend='ods',

--- a/udata_ods/harvesters.py
+++ b/udata_ods/harvesters.py
@@ -136,7 +136,8 @@ class OdsBackend(BaseBackend):
         ods_metadata = ods_dataset['metas']
         ods_interopmetas = ods_dataset.get('interop_metas', {})
 
-        if not ods_dataset.get('has_records'):
+        if not any((ods_dataset.get(attr) for attr
+                    in ('has_records', 'attachments', 'alternative_exports'))):
             msg = 'Dataset {datasetid} has no record'.format(**ods_dataset)
             raise HarvestSkipException(msg)
 
@@ -220,6 +221,8 @@ class OdsBackend(BaseBackend):
         return False, resource
 
     def process_resources(self, dataset, data, formats):
+        if not data.get('has_records'):
+            return
         dataset_id = data['datasetid']
         ods_metadata = data['metas']
         modified_at = self.parse_date(ods_metadata['modified'])


### PR DESCRIPTION
This PR ensure datasets without records but with attachments like [this one](https://data.loire-atlantique.fr/explore/dataset/224400028_enquete-deplacements-en-loire-atlantique/information/) are properly harvested.