### PR TITLE
Point to file with machine names as headers, instead of labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Point exports (resources) to a version of the file with machine names as headers, instead of labels [#169](https://github.com/opendatateam/udata-ods/pull/169)
 
 ## 2.0.1 (2020-03-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Point exports (resources) to a version of the file with machine names as headers, instead of labels [#169](https://github.com/opendatateam/udata-ods/pull/169)
+- Link exports (resources) to a version of the file with machine names as headers, instead of labels [#169](https://github.com/opendatateam/udata-ods/pull/169)
 
 ## 2.0.1 (2020-03-24)
 

--- a/tests/test_ods_backend.py
+++ b/tests/test_ods_backend.py
@@ -123,7 +123,7 @@ def test_simple(rmock):
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-a/download'
                             '?format=csv&timezone=Europe/Berlin'
-                            '&use_labels_for_header=true')
+                            '&use_labels_for_header=false')
     assert resource.extras['ods:type'] == 'api'
 
     resource = d.resources[1]
@@ -135,7 +135,7 @@ def test_simple(rmock):
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-a/download'
                             '?format=json&timezone=Europe/Berlin'
-                            '&use_labels_for_header=true')
+                            '&use_labels_for_header=false')
     assert resource.extras['ods:type'] == 'api'
 
     # test-b has geo feature
@@ -157,7 +157,7 @@ def test_simple(rmock):
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-b/download'
                             '?format=geojson&timezone=Europe/Berlin'
-                            '&use_labels_for_header=true')
+                            '&use_labels_for_header=false')
     resource = test_b.resources[3]
     assert resource.title == 'Shapefile format export'
     assert resource.description is not None
@@ -166,7 +166,7 @@ def test_simple(rmock):
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-b/download'
                             '?format=shp&timezone=Europe/Berlin'
-                            '&use_labels_for_header=true')
+                            '&use_labels_for_header=false')
 
     resource = test_b.resources[4]
     assert resource.title == 'gtfs.zip'

--- a/udata_ods/harvesters.py
+++ b/udata_ods/harvesters.py
@@ -93,7 +93,7 @@ class OdsBackend(BaseBackend):
 
     def download_url(self, dataset_id, format):
         return ('{0}download?format={1}&timezone=Europe/Berlin'
-                '&use_labels_for_header=true'
+                '&use_labels_for_header=false'
                 ).format(self.explore_url(dataset_id), format)
 
     def export_url(self, dataset_id):


### PR DESCRIPTION
Point exports (resources) to a version of the file with machine names as headers, instead of labels.