### PR TITLE
Store geojson format instead of json when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Store geojson format instead of json when relevant [#212](https://github.com/opendatateam/udata-ods/pull/212)
 
 ## 2.1.0 (2020-10-16)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -1,5 +1,5 @@
 -e .[test]
-flake8==3.7.7
-invoke==1.2.0
+flake8==3.7.8
+invoke==1.3.0
 pytest-cov==2.6.1
-readme-renderer[md]==24.0
+readme-renderer[md]==29.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,4 +1,4 @@
-mock==2.0.0
+mock==3.0.5
 pytest==4.6.3
 pytest-flask==0.15.0
 pytest-sugar==0.9.2

--- a/tests/test_ods_backend.py
+++ b/tests/test_ods_backend.py
@@ -152,7 +152,7 @@ def test_simple(rmock):
     resource = test_b.resources[2]
     assert resource.title == 'GeoJSON format export'
     assert resource.description is not None
-    assert resource.format == 'json'
+    assert resource.format == 'geojson'
     assert resource.mime == 'application/vnd.geo+json'
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-b/download'

--- a/udata_ods/harvesters.py
+++ b/udata_ods/harvesters.py
@@ -67,7 +67,7 @@ class OdsBackend(BaseBackend):
 
     FORMATS = {
         'csv': ('CSV', 'csv', 'text/csv'),
-        'geojson': ('GeoJSON', 'json', 'application/vnd.geo+json'),
+        'geojson': ('GeoJSON', 'geojson', 'application/vnd.geo+json'),
         'json': ('JSON', 'json', 'application/json'),
         'shp': ('Shapefile', 'shp', None),
     }
@@ -180,6 +180,8 @@ class OdsBackend(BaseBackend):
         dataset.license = License.guess(license_id,
                                         self.LICENSES.get(license_id),
                                         default=default_license)
+        if self.explore_url(dataset_id)=='https://saint-louis-agglo.opendatasoft.com/explore/dataset/communes_elus/':
+            breakpoint()
 
         self.process_resources(dataset, ods_dataset, ('csv', 'json'))
 

--- a/udata_ods/harvesters.py
+++ b/udata_ods/harvesters.py
@@ -180,8 +180,6 @@ class OdsBackend(BaseBackend):
         dataset.license = License.guess(license_id,
                                         self.LICENSES.get(license_id),
                                         default=default_license)
-        if self.explore_url(dataset_id)=='https://saint-louis-agglo.opendatasoft.com/explore/dataset/communes_elus/':
-            breakpoint()
 
         self.process_resources(dataset, ods_dataset, ('csv', 'json'))
 


### PR DESCRIPTION
Fix https://github.com/opendatateam/udata-ods/issues/211

Do you know any historic on why `json` was used when storing format in udata instead of `geojson` @abulte?