### PR TITLE
Remove github release job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,18 +84,6 @@ jobs:
             pip install twine
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
-  github:
-    docker:
-      - image: udata/circleci:2-alpine
-    environment:
-       BASH_ENV: /root/.bashrc
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Upload github release
-          command: gh_release
-
 workflows:
   version: 2
   build:
@@ -105,15 +93,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
       - publish:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-          context: org-global
-      - github:
           requires:
             - build
           filters:


### PR DESCRIPTION
This job now fails, making release jobs look like a failure :cry: 
Ex: https://app.circleci.com/pipelines/github/opendatateam/udata-ods/198/workflows/5ee4c1c6-d90b-4b07-afae-2c5a3d50cfca

Since we want to standardize our CI between the different udata projects, I suggest to remove this job for now.
We could decide later on to re-introduce a github release on our udata projects.