### PR TITLE
Fix/can preview ods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix can_explore on dataset with both ODS and non-ODS resources [#244](https://github.com/opendatateam/udata-ods/pull/244)
 
 ## 3.0.0 (2022-11-14)
 

--- a/tests/test_ods_preview.py
+++ b/tests/test_ods_preview.py
@@ -71,6 +71,21 @@ def test_display_preview_only_for_ods_resources():
     assert resource.preview_url is None
 
 
+def test_display_preview_with_mixed_resources():
+    domain = faker.domain_name()
+    remote_id = faker.unique_string()
+    resource_ods = ResourceFactory(harvest=HarvestResourceMetadata(ods_type='api'))
+    resource_other = ResourceFactory()
+    _ = DatasetFactory(resources=[resource_other, resource_ods], harvest=HarvestDatasetMetadata(
+        remote_id=remote_id,
+        domain=domain,
+        ods_url='http://url.com'
+    ))
+
+    assert resource_ods.preview_url is not None
+    assert resource_other.preview_url is None
+
+
 def test_no_preview_for_community_resources():
     domain = faker.domain_name()
     remote_id = faker.unique_string()

--- a/udata_ods/preview.py
+++ b/udata_ods/preview.py
@@ -11,7 +11,7 @@ class OdsPreview(PreviewPlugin):
         dataset = resource.dataset
         if not dataset.harvest or 'ods_url' not in dataset.harvest._data:
             return
-        return resource.harvest._data.get('ods_type') == 'api'
+        return resource.harvest and resource.harvest._data.get('ods_type') == 'api'
 
     def preview_url(self, resource):
         dataset = resource.dataset


### PR DESCRIPTION
Fix `can_explore` function on ODS dataset with both lambda and ODS resources.

Example bug on [Base officielle des codes postaux](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/) second resource, if you try to access it's preview_url, leading to the empty grey button.
I'm not sure why it fails silently though but it seems to raise a 500 on the new dataset page.