### PR TITLE
Add migration that removes duplicate resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
-            pip install setuptools==66.1.1
+            pip install --force-reinstall setuptools==66.1.1
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add migration that removes duplicate resources [#248](https://github.com/opendatateam/udata-ods/pull/248)
 
 ## 3.0.1 (2023-02-06)
 

--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -1,5 +1,5 @@
 -e .[test]
 flake8==3.7.8
-invoke==1.3.0
-pytest-cov==2.6.1
+invoke==1.7.3
+pytest-cov==4.0.0
 readme-renderer[md]==29.0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,5 @@
-mock==3.0.5
-pytest==4.6.3
-pytest-flask==0.15.0
-pytest-sugar==0.9.2
-requests-mock==1.7.0
+mock==5.0.1
+pytest==7.2.1
+pytest-flask==1.2.0
+pytest-sugar==0.9.6
+requests-mock==1.10.0

--- a/tests/test_ods_backend.py
+++ b/tests/test_ods_backend.py
@@ -10,6 +10,7 @@ from udata.models import Dataset, License
 from udata.core.organization.factories import OrganizationFactory
 from udata.harvest import actions
 from udata.harvest.tests.factories import HarvestSourceFactory
+from udata.i18n import gettext as _
 from udata.utils import faker
 
 from udata_ods.harvesters import OdsBackend
@@ -117,11 +118,11 @@ def test_simple(rmock):
 
     assert len(d.resources) == 2
     resource = d.resources[0]
-    assert resource.title == 'CSV format export'
+    assert resource.title == _('{format} format export').format(format='CSV')
     assert resource.description is not None
     assert resource.format == 'csv'
     assert resource.mime == 'text/csv'
-    assert isinstance(resource.modified, datetime)
+    assert isinstance(resource.harvest.modified_at, datetime)
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-a/download'
                             '?format=csv&timezone=Europe/Berlin'
@@ -129,11 +130,11 @@ def test_simple(rmock):
     assert resource.harvest.ods_type == 'api'
 
     resource = d.resources[1]
-    assert resource.title == 'JSON format export'
+    assert resource.title == _('{format} format export').format(format='JSON')
     assert resource.description is not None
     assert resource.format == 'json'
     assert resource.mime == 'application/json'
-    assert isinstance(resource.modified, datetime)
+    assert isinstance(resource.harvest.modified_at, datetime)
     assert resource.url == ('http://etalab-sandbox.opendatasoft.com/'
                             'explore/dataset/test-a/download'
                             '?format=json&timezone=Europe/Berlin'
@@ -153,7 +154,7 @@ def test_simple(rmock):
     assert len(test_b.resources) == 7
     resource_ids = set([r.id for r in test_b.resources])
     resource = test_b.resources[2]
-    assert resource.title == 'GeoJSON format export'
+    assert resource.title == _('{format} format export').format(format='GeoJSON')
     assert resource.description is not None
     assert resource.format == 'geojson'
     assert resource.mime == 'application/vnd.geo+json'
@@ -162,7 +163,7 @@ def test_simple(rmock):
                             '?format=geojson&timezone=Europe/Berlin'
                             '&use_labels_for_header=false')
     resource = test_b.resources[3]
-    assert resource.title == 'Shapefile format export'
+    assert resource.title == _('{format} format export').format(format='Shapefile')
     assert resource.description is not None
     assert resource.format == 'shp'
     assert resource.mime is None

--- a/udata_ods/migrations/2023-07-12-remove-double-slash-resource.py
+++ b/udata_ods/migrations/2023-07-12-remove-double-slash-resource.py
@@ -1,0 +1,38 @@
+
+'''
+Remove ODS resources that are duplicate of resource with one slash only
+'''
+import logging
+
+from udata.models import Dataset
+from udata.harvest.models import HarvestSource
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info('Processing Harvest Sources.')
+
+    # sources with trailing slash
+    sources = HarvestSource.objects(
+        url__regex="/$",
+        backend="ods",
+        created_at__lte="2018-05-01").no_cache().timeout(False)
+    for source in sources:
+        log.info(f'Processing source {source} ({source.id})')
+        for dat in Dataset.objects(harvest__source_id=str(source.id),
+                                   resources__url__contains=source.url + '/'):
+            to_delete = []
+            for res in dat.resources:
+                log.info(res.url)
+                # Check if this resource has the double slash due to the source url
+                if not source.url + '/' in res.url:
+                    continue
+                # Check if the same resource exists with a single slash
+                one_slash_url = res.url.replace(source.url, source.url.rstrip('/'))
+                if any(r.url == one_slash_url for r in dat.resources):
+                    to_delete.append(res)
+                    log.info('->: DELETE')
+            for res in to_delete:
+                dat.remove_resource(res)
+            dat.save()


### PR DESCRIPTION
Due to https://github.com/opendatateam/udata-ods/pull/2, resources had been duplicated in case of trailing slash in domain. Example: http://data.gouv.fr/fr/datasets/marches-publics-angers-loire-metropole-2014/

This PR adds a migration to remove double slash resources.